### PR TITLE
Changed from process.ARGV to process.argv due to undefined error.

### DIFF
--- a/jshint-mode.js
+++ b/jshint-mode.js
@@ -19,8 +19,8 @@ var hinters = {
 };
 
 function getOpt(key) {
-  var index = process.ARGV.indexOf(key);
-  return index !== -1 ? process.ARGV[index + 1] : false;
+  var index = process.argv.indexOf(key);
+  return index !== -1 ? process.argv[index + 1] : false;
 }
 
 function outputErrors(errors) {


### PR DESCRIPTION
Changed process.ARGV to process.argv in jshint-mode.js because I was getting
# 

node.js:201
        throw e; // process.nextTick error, or 'error' event on first tick
              ^
TypeError: Cannot call method 'indexOf' of undefined
    at getOpt (/usr/local/lib/node_modules/jshint-mode/jshint-mode.js:22:28)
    at Object.<anonymous> (/usr/local/lib/node_modules/jshint-mode/jshint-mode.js:51:12)
    at Module._compile (module.js:432:26)
    at Object..js (module.js:450:10)
    at Module.load (module.js:351:31)
    at Function._load (module.js:310:12)
    at Array.0 (module.js:470:10)
    at EventEmitter._tickCallback (node.js:192:40)
# Process jshint-mode-server exited abnormally with code 1

From Node.js documentation, process.argv seems to be the right property.
http://nodejs.org/docs/latest/api/process.html#process.argv
