### PR TITLE
Automatically locate and use correct .jshintrc

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -54,6 +54,18 @@ You can use M-x flymake-mode to turn flymake of and on, if you want to turn it o
     ;; Turns on flymake for all files which have a flymake mode
     (add-hook 'find-file-hook 'flymake-find-file-hook)
 
+
+Using .jshintrc
+---------------
+
+By default, jshint-mode will search for the nearest `.jshintrc` file up the
+directory tree from the location of each JS file you edit.
+
+Alternatively, you can customize the `jshint-mode-jshintrc` variable to set the
+location of a `.jshintrc` file that will always be used (and will be the only
+one used).
+
+
 Note to Emacs.app users
 =======================
 

--- a/flymake-jshint.el
+++ b/flymake-jshint.el
@@ -78,11 +78,16 @@
       (let* ((temp-file (flymake-init-create-temp-buffer-copy 'flymake-create-temp-inplace))
              (local-file (file-relative-name temp-file
                                              (file-name-directory buffer-file-name)))
-             (jshint-url (format "http://%s:%d/check" jshint-mode-host jshint-mode-port)))
+             (jshint-url (format "http://%s:%d/check" jshint-mode-host jshint-mode-port))
+             (jshintrc (if (string= "" jshint-mode-jshintrc)
+                           (expand-file-name
+                            ".jshintrc"
+                            (locate-dominating-file default-directory ".jshintrc"))
+                         jshint-mode-jshintrc)))
         (list "curl" (list "--form" (format "source=<%s" local-file)
                            "--form" (format "filename=%s" local-file)
                            "--form" (format "mode=%s" jshint-mode-mode)
-                           "--form" (format "jshintrc=%s" jshint-mode-jshintrc)
+                           "--form" (format "jshintrc=%s" jshintrc)
                            jshint-url)))))
 
 (setq flymake-allowed-file-name-masks

--- a/flymake-jshint.el
+++ b/flymake-jshint.el
@@ -42,7 +42,7 @@
   :group 'flymake-jshint)
 
 (defcustom jshint-mode-jshintrc ""
-  "Location for the jshintrc file."
+  "Location for the jshintrc file. If not set, looks up directory tree from each JS file."
   :type 'string
   :group 'flymake-jshint)
 


### PR DESCRIPTION
Currently, the `.jshintrc` support requires setting a global config var pointing to the location of the `.jshintrc` file. This adds an extra configuration step (currently not documented in the README), and makes it difficult to work on multiple different projects with different `.jshintrc` files.

Ideally, each time `flymake` is initialized on a new buffer, it would use the Emacs function `locate-dominating-file` to automatically find the nearest `.jshintrc` file in containing directories, and automatically use that `.jshintrc` for that buffer.
