### PR TITLE
Support for custom module paths for jshint/jslint

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -65,6 +65,25 @@ Alternatively, you can customize the `jshint-mode-jshintrc` variable to set the
 location of a `.jshintrc` file that will always be used (and will be the only
 one used).
 
+Custom installations of jshint/jslint
+-------------------------------------
+
+You can use `jshint-mode-jshint-path`/`jshint-mode-jslint-path` to set
+the require path for the jshint module.
+
+For the global installation of jshint, you can set
+`jshint-mode-jshint-path` to "jshint"
+
+    (setq jshint-mode-jshint-path "jshint")
+
+Or for other installations you can point to the corresponding library
+via the absolute path. Eg:
+
+    (setq jshint-mode-jshint-path
+     "/home/rohan/.local/lib/node_modules/jshint/src/jshint.js")
+
+By default, `jshint-mode` will use the bundled snapshots the linting
+tools.
 
 Note to Emacs.app users
 =======================

--- a/flymake-jshint.el
+++ b/flymake-jshint.el
@@ -46,6 +46,16 @@
   :type 'string
   :group 'flymake-jshint)
 
+(defcustom jshint-mode-jshint-path ""
+  "Require path for the jshint module to be used by the server. If not set, uses flymake-jshint's bundled jshint."
+  :type 'string
+  :group 'flymake-jshint)
+
+(defcustom jshint-mode-jslint-path ""
+  "Require path for the jslint module to be used by the server. If not set, uses flymake-jshint's bundled jslint."
+  :type 'string
+  :group 'flymake-jshint)
+
 (setq jshint-process "jshint-mode-server")
 (setq jshint-buffer "*jshint-mode*")
 
@@ -60,7 +70,9 @@
      jshint-mode-node-program
      (expand-file-name (concat jshint-mode-location "/jshint-mode.js"))
      "--host" jshint-mode-host
-     "--port" (number-to-string jshint-mode-port))
+     "--port" (number-to-string jshint-mode-port)
+     "--jshint" jshint-mode-jshint-path
+     "--jslint" jshint-mode-jslint-path)
     (set-process-query-on-exit-flag (get-process jshint-process) nil)
     (message
      (concat "jshint server has started on " jshint-mode-host ":"

--- a/jshint-mode.js
+++ b/jshint-mode.js
@@ -46,7 +46,8 @@ function outputErrors(errors) {
 }
 
 function lintify(mode, sourcedata, filename, config) {
-  var passed = hinters[mode](sourcedata, config);
+  var globals = config.globals;
+  var passed = hinters[mode](sourcedata, config, globals);
   return passed ? "js: No problems found in " + filename + "\n"
     : outputErrors(hinters[mode].errors);
 }

--- a/jshint-mode.js
+++ b/jshint-mode.js
@@ -8,21 +8,23 @@
     speed up
 */
 
-var http = require('http'),
+var JSLINT, JSHINT,
+    http = require('http'),
     formidable = require('formidable'),
-    fs = require('fs'),
-    JSLINT = require('./jslint'),
-    JSHINT = require('./jshint');
-
-var hinters = {
-  jshint: JSHINT.JSHINT,
-  jslint: JSLINT.JSLINT
-};
+    fs = require('fs');
 
 function getOpt(key) {
   var index = process.argv.indexOf(key);
   return index !== -1 ? process.argv[index + 1] : false;
 }
+
+JSLINT = require(getOpt('--jslint') || './jslint');
+JSHINT = require(getOpt('--jshint') || './jshint');
+
+var hinters = {
+  jshint: JSHINT.JSHINT,
+  jslint: JSLINT.JSLINT
+};
 
 function outputErrors(errors) {
 


### PR DESCRIPTION
Alternatively to the bundled jshint.js and jslint.js, the global
`jshint` and `jslint` modules can be defined by setting
`jshint-mode-jshint-path` or `jshint-mode-jshint-path` in emacs
configuration.

Eg: For the global installation of jshint, set
`jshint-mode-jshint-path` to "jshint"

```
(setq jshint-mode-jshint-path "jshint")
```

Ref issue: #16
