### PR TITLE
Allow multiple jshint-mode servers to run simultaneously (allows multiple emacs windows)

### DIFF
--- a/flymake-jshint.el
+++ b/flymake-jshint.el
@@ -36,6 +36,11 @@
   :type 'integer
   :group 'flymake-jshint)
 
+(defcustom jshint-mode-lastport 3100
+  "Defines the higher end of the port range to run on."
+  :type 'integer
+  :group 'flymake-jshint)
+
 (defcustom jshint-mode-host "127.0.0.1"
   "The host the jshint-mode server runs on."
   :type 'string
@@ -48,23 +53,51 @@
 
 (setq jshint-process "jshint-mode-server")
 (setq jshint-buffer "*jshint-mode*")
+(setq jshint-dynamic-port nil) ;; server prints on stdout. we grep for it
+(setq jshint-process-output nil)
+(setq jshint-start-regex "\\`Started[^:]+://\\([^:]+\\):\\([0-9]+\\)[\.]")
+
+;; The server might try different ports before starting.
+;; We locate the port in the stdout messages.
+(defun jshint-extract-port-filter (proc string)
+  ;; the following block just adds the output to the process buffer
+  (when (buffer-live-p (process-buffer proc))
+    (with-current-buffer (process-buffer proc)
+      (let ((moving (= (point) (process-mark proc))))
+	(save-excursion
+	  ;; Insert the text, advancing the process marker.
+	  (goto-char (process-mark proc))
+	  (insert string)
+	  (set-marker (process-mark proc) (point)))
+	(if moving (goto-char (process-mark proc))))))
+
+  (when (eq jshint-dynamic-port nil)
+    (setq jshint-process-output (concat jshint-process-output string)) ;; all text received so far
+    (save-match-data
+      (when (string-match jshint-start-regex jshint-process-output)
+	(setq jshint-dynamic-port (string-to-number (match-string 2 jshint-process-output)))
+	(message
+	 (concat "jshint server has started on " jshint-mode-host ":"
+		 (number-to-string jshint-dynamic-port)))
+	(set-process-filter (get-process jshint-process) nil)))))
 
 (defun jshint-mode-init ()
   "Start the jshint-mode server."
   (interactive)
   (if (eq (process-status jshint-process) 'run)
-      'started
+      (if (not (eq jshint-dynamic-port nil))
+	  'started
+	'starting)
     (start-process
      jshint-process
      jshint-buffer
      jshint-mode-node-program
      (expand-file-name (concat jshint-mode-location "/jshint-mode.js"))
      "--host" jshint-mode-host
-     "--port" (number-to-string jshint-mode-port))
+     "--port" (number-to-string jshint-mode-port)
+     "--lastport" (number-to-string jshint-mode-lastport))
+    (set-process-filter (get-process jshint-process) 'jshint-extract-port-filter)
     (set-process-query-on-exit-flag (get-process jshint-process) nil)
-    (message
-     (concat "jshint server has started on " jshint-mode-host ":"
-             (number-to-string jshint-mode-port)))
     'starting
     ))
 
@@ -78,7 +111,7 @@
       (let* ((temp-file (flymake-init-create-temp-buffer-copy 'flymake-create-temp-inplace))
              (local-file (file-relative-name temp-file
                                              (file-name-directory buffer-file-name)))
-             (jshint-url (format "http://%s:%d/check" jshint-mode-host jshint-mode-port))
+             (jshint-url (format "http://%s:%d/check" jshint-mode-host jshint-dynamic-port))
              (jshintrc (if (string= "" jshint-mode-jshintrc)
                            (expand-file-name
                             ".jshintrc"

--- a/jshint-mode.js
+++ b/jshint-mode.js
@@ -14,6 +14,10 @@ var http = require('http'),
     JSLINT = require('./jslint'),
     JSHINT = require('./jshint');
 
+if (!fs.existsSync) {
+  fs.existsSync = require('path').existsSync;
+}
+
 var hinters = {
   jshint: JSHINT.JSHINT,
   jslint: JSLINT.JSLINT


### PR DESCRIPTION
The first flymake-jshint starts a server on the base port (3003), but subsequent windows (either in console or graphical mode) fail to enable flymake-jshint due to the port being already in use. Reusing the same server for all lint request would work only as long as the initial window is kept open (flymake processes are cleaned up on exit).

This pull request changes it so that each window starts its own server on the first available port in a range (3003 to 3100). At the time the node process is started in emacs, the port is not known, so there is a bit of emacs lisp code in there to extract the port from the subprocess' stdout. The end result is that multiple emacs windows open can all benefit from the syntax checking.

(heads up: the branch also has a commit to close issue #32)
