### PR TITLE
Various improvements and bugfix to allow editing files with minified sections.

### DIFF
--- a/flymake-cursor.el
+++ b/flymake-cursor.el
@@ -1,0 +1,167 @@
+;;; flymake-cursor.el --- displays flymake error msg in minibuffer after delay
+;;
+;; Author     : ??
+;; origin     : http://paste.lisp.org/display/60617,1/raw
+;; Maintainer : Dino Chiesa <dpchiesa@hotmail.com>
+;;            : Donald Curtis <dcurtis@milkbox.net>
+;; Created    : May 2011
+;; Modified   : December 2012
+;; Version    : 0.1.5
+;; Keywords   : languages mode flymake
+;; X-URL      : http://www.emacswiki.org/emacs/flymake-cursor.el
+;; Last-saved : <2012-Dec-20 09:49:28>
+;;
+;; -------------------------------------------------------
+;;
+;; License: None.  This code is in the Public Domain.
+;;
+;;
+;; Additional functionality that makes flymake error messages appear
+;; in the minibuffer when point is on a line containing a flymake
+;; error. This saves having to mouse over the error, which is a
+;; keyboard user's annoyance.
+;; -------------------------------------------------------
+;;
+;; This flymake-cursor module displays the flymake error in the
+;; minibuffer, after a short delay.  It is based on code I found roaming
+;; around on the net, unsigned and unattributed. I suppose it's public
+;; domain, because, while there is a "License" listed in it, there
+;; is no license holder, no one to own the license.
+;;
+;; This version is modified slightly from that code. The post-command fn
+;; defined in this code does not display the message directly. Instead
+;; it sets a timer, and when the timer fires, the timer event function
+;; displays the message.
+;;
+;; The reason to do this: the error message is displayed only if the
+;; user doesn't do anything, for about one second. This way, if the user
+;; scrolls through a buffer and there are myriad errors, the minibuffer
+;; is not constantly being updated.
+;;
+;; If the user moves away from the line with the flymake error message
+;; before the timer expires, then no error is displayed in the minibuffer.
+;;
+;; I've also updated the names of the defuns. They all start with flyc now.
+;;
+;; To use this, include this line in your .emacs:
+;;
+;;    ;; enhancements for displaying flymake errors
+;;    (require 'flymake-cursor)
+;;
+;; You can, of course, put that in an eval-after-load clause.
+;;
+;; -------------------------------------------------------
+;;
+;; Update 2012-03-06 by Donald Curtis
+;; --
+;; Added some autoload statements and the closing comment to make
+;; compatible with package.el parser.
+;;
+;; Update 2012-12-20 by Jeremy Moore
+;; --
+;; Alter post-command-hook's local value via add-hook so that it plays
+;; nicely with other packages.
+;;
+
+
+(require 'cl)
+
+(defvar flyc--e-at-point nil
+  "Error at point, after last command")
+
+(defvar flyc--e-display-timer nil
+  "A timer; when it fires, it displays the stored error message.")
+
+(defun flyc/maybe-fixup-message (errore)
+  "pyflake is flakey if it has compile problems, this adjusts the
+message to display, so there is one ;)"
+  (cond ((not (or (eq major-mode 'Python) (eq major-mode 'python-mode) t)))
+        ((null (flymake-ler-file errore))
+         ;; normal message do your thing
+         (flymake-ler-text errore))
+        (t ;; could not compile error
+         (format "compile error, problem on line %s" (flymake-ler-line errore)))))
+
+(defun flyc/show-stored-error-now ()
+  "Displays the stored error in the minibuffer."
+  (interactive)
+  (let ((editing-p (= (minibuffer-depth) 0)))
+   (if (and flyc--e-at-point editing-p)
+       (progn
+         (message "%s" (flyc/maybe-fixup-message flyc--e-at-point))
+         (setq flyc--e-display-timer nil)))))
+
+
+(defun flyc/-get-error-at-point ()
+  "Gets the first flymake error on the line at point."
+  (let ((line-no (line-number-at-pos))
+        flyc-e)
+    (dolist (elem flymake-err-info)
+      (if (eq (car elem) line-no)
+          (setq flyc-e (car (second elem)))))
+    flyc-e))
+
+
+;;;###autoload
+(defun flyc/show-fly-error-at-point-now ()
+  "If the cursor is sitting on a flymake error, display
+the error message in the  minibuffer."
+  (interactive)
+  (if flyc--e-display-timer
+      (progn
+        (cancel-timer flyc--e-display-timer)
+        (setq flyc--e-display-timer nil)))
+  (let ((error-at-point (flyc/-get-error-at-point)))
+    (if error-at-point
+        (progn
+          (setq flyc--e-at-point error-at-point)
+          (flyc/show-stored-error-now)))))
+
+
+;;;###autoload
+(defun flyc/show-fly-error-at-point-pretty-soon ()
+  "If the cursor is sitting on a flymake error, grab the error,
+and set a timer for \"pretty soon\". When the timer fires, the error
+message will be displayed in the minibuffer.
+
+This allows a post-command-hook to NOT cause the minibuffer to be
+updated 10,000 times as a user scrolls through a buffer
+quickly. Only when the user pauses on a line for more than a
+second, does the flymake error message (if any) get displayed.
+
+"
+  (if flyc--e-display-timer
+      (cancel-timer flyc--e-display-timer))
+
+  (let ((error-at-point (flyc/-get-error-at-point)))
+    (if error-at-point
+        (setq flyc--e-at-point error-at-point
+              flyc--e-display-timer
+              (run-at-time "0.9 sec" nil 'flyc/show-stored-error-now))
+      (setq flyc--e-at-point nil
+            flyc--e-display-timer nil))))
+
+
+;;;###autoload
+(eval-after-load "flymake"
+  '(progn
+
+     (defadvice flymake-goto-next-error (after flyc/display-message-1 activate compile)
+       "Display the error in the mini-buffer rather than having to mouse over it"
+       (flyc/show-fly-error-at-point-now))
+
+     (defadvice flymake-goto-prev-error (after flyc/display-message-2 activate compile)
+       "Display the error in the mini-buffer rather than having to mouse over it"
+       (flyc/show-fly-error-at-point-now))
+
+     (defadvice flymake-mode (before flyc/post-command-fn activate compile)
+       "Add functionality to the post command hook so that if the
+cursor is sitting on a flymake error the error information is
+displayed in the minibuffer (rather than having to mouse over
+it)"
+       (add-hook 'post-command-hook 'flyc/show-fly-error-at-point-pretty-soon t t))))
+
+
+(provide 'flymake-cursor)
+
+;;; flymake-cursor.el ends here

--- a/flymake-jshint.el
+++ b/flymake-jshint.el
@@ -124,7 +124,7 @@
                            jshint-url)))))
 
 (setq flymake-allowed-file-name-masks
-      (cons '(".+\\.js$"
+      (cons '(".+\\.js\\(\\.in\\)?$"
 	      flymake-jshint-init
 	      flymake-simple-cleanup
 	      flymake-get-real-file-name)

--- a/flymake-jshint.el
+++ b/flymake-jshint.el
@@ -36,6 +36,11 @@
   :type 'integer
   :group 'flymake-jshint)
 
+(defcustom jshint-mode-lastport 3100
+  "Defines the higher end of the port range to run on."
+  :type 'integer
+  :group 'flymake-jshint)
+
 (defcustom jshint-mode-host "127.0.0.1"
   "The host the jshint-mode server runs on."
   :type 'string
@@ -48,23 +53,51 @@
 
 (setq jshint-process "jshint-mode-server")
 (setq jshint-buffer "*jshint-mode*")
+(setq jshint-dynamic-port nil) ;; server prints on stdout. we grep for it
+(setq jshint-process-output nil)
+(setq jshint-start-regex "\\`Started[^:]+://\\([^:]+\\):\\([0-9]+\\)[\.]")
+
+;; The server might try different ports before starting.
+;; We locate the port in the stdout messages.
+(defun jshint-extract-port-filter (proc string)
+  ;; the following block just adds the output to the process buffer
+  (when (buffer-live-p (process-buffer proc))
+    (with-current-buffer (process-buffer proc)
+      (let ((moving (= (point) (process-mark proc))))
+	(save-excursion
+	  ;; Insert the text, advancing the process marker.
+	  (goto-char (process-mark proc))
+	  (insert string)
+	  (set-marker (process-mark proc) (point)))
+	(if moving (goto-char (process-mark proc))))))
+
+  (when (eq jshint-dynamic-port nil)
+    (setq jshint-process-output (concat jshint-process-output string)) ;; all text received so far
+    (save-match-data
+      (when (string-match jshint-start-regex jshint-process-output)
+	(setq jshint-dynamic-port (string-to-number (match-string 2 jshint-process-output)))
+	(message
+	 (concat "jshint server has started on " jshint-mode-host ":"
+		 (number-to-string jshint-dynamic-port)))
+	(set-process-filter (get-process jshint-process) nil)))))
 
 (defun jshint-mode-init ()
   "Start the jshint-mode server."
   (interactive)
   (if (eq (process-status jshint-process) 'run)
-      'started
+      (if (not (eq jshint-dynamic-port nil))
+	  'started
+	'starting)
     (start-process
      jshint-process
      jshint-buffer
      jshint-mode-node-program
      (expand-file-name (concat jshint-mode-location "/jshint-mode.js"))
      "--host" jshint-mode-host
-     "--port" (number-to-string jshint-mode-port))
+     "--port" (number-to-string jshint-mode-port)
+     "--lastport" (number-to-string jshint-mode-lastport))
+    (set-process-filter (get-process jshint-process) 'jshint-extract-port-filter)
     (set-process-query-on-exit-flag (get-process jshint-process) nil)
-    (message
-     (concat "jshint server has started on " jshint-mode-host ":"
-             (number-to-string jshint-mode-port)))
     'starting
     ))
 
@@ -78,7 +111,7 @@
       (let* ((temp-file (flymake-init-create-temp-buffer-copy 'flymake-create-temp-inplace))
              (local-file (file-relative-name temp-file
                                              (file-name-directory buffer-file-name)))
-             (jshint-url (format "http://%s:%d/check" jshint-mode-host jshint-mode-port))
+             (jshint-url (format "http://%s:%d/check" jshint-mode-host jshint-dynamic-port))
              (jshintrc (if (string= "" jshint-mode-jshintrc)
                            (expand-file-name
                             ".jshintrc"

--- a/jshint-emacs.js
+++ b/jshint-emacs.js
@@ -1,8 +1,8 @@
 #!/usr/bin/env node
 
-var conf = '\n(add-to-list \'load-path "' + __dirname + '")\n'
-  + '(require \'flymake-jshint)\n'
-  + '(add-hook \'javascript-mode-hook\n'
-  + '    (lambda () (flymake-mode t)))';
+var conf = '\n(add-to-list \'load-path "' + __dirname + '")\n' +
+  '(require \'flymake-jshint)\n' +
+  '(add-hook \'javascript-mode-hook\n' +
+  '(lambda () (flymake-mode t)))';
 
 console.log(conf);

--- a/jshint-mode.js
+++ b/jshint-mode.js
@@ -1,6 +1,37 @@
 /* HTTP interface to JSHint.
 
-   curl --form source="<path/to/my.js" --form=filename="my.js" http://127.0.0.1:3003/jshint
+   curl --form source="<path/to/my.js" --form=filename="my.js" --form mode=jshint --form showCode=1 http://127.0.0.1:3003/check
+
+    POST parameters:
+
+      source the contents of the file (the < is a curl construct which
+             inlines the contents of the file in the param).
+
+      filename is the name of that file
+
+      mode     The linter to use. 'jshint' or 'jslint' (default jshint).
+
+      showCode Whether to include source code evidence with the
+               errors. '0' or '1' (default '0'). Not including error
+               content speeds up flymake parsing and operation.
+
+   CLI Usage:
+        jshint-mode.js  --host HOST --port PORT --lastport LASTPORT
+
+        Start listening at address HOST. The first port between PORT
+	and LASTPORT is used for listening (default 3003-3003). The
+	chosen port is printed on stdout on the first line output.
+
+	Dynamic ports are needed when the server is started by emacs
+	flymake. Multiple emacs processes can use the same server
+	endpoint, but the server is shut down when one window is
+	closed. By allowing each flymake process to start its own
+	server on a different port, cleanup of one window does not
+	interfere with another's.
+
+	Example output indicating address and port:
+
+        'Started JSHint server at http://127.0.0.1:3003'
 
   TODO:
     parse incoming source files for embedded jshint options

--- a/jshint-mode.js
+++ b/jshint-mode.js
@@ -14,6 +14,10 @@ var http = require('http'),
     JSLINT = require('./jslint'),
     JSHINT = require('./jshint');
 
+if (!fs.existsSync) {
+  fs.existsSync = require('path').existsSync;
+}
+
 var hinters = {
   jshint: JSHINT.JSHINT,
   jslint: JSLINT.JSLINT

--- a/jshint-mode.js
+++ b/jshint-mode.js
@@ -93,11 +93,13 @@ var server = http.createServer(function(req, res) {
     form.parse(req, function(err, fields, files) {
       var mode = (fields.mode && fields.mode == "jslint") ? "jslint" : "jshint";
 
+      var now = new Date().getTime();
       console.log('Applying \'' + mode + '\' to: ' + (fields.filename || 'anonymous'));
 
       var config = _getConfig(fields.jshintrc);
 
       var results = lintify(mode, fields.source, fields.filename, config);
+      console.log('Took ' + (new Date().getTime() - now) + 'ms to lint ' + (fields.filename || 'anonymous'));
       res.writeHead(200, {'Content-Type': 'text/plain'});
       res.end(results);
     });


### PR DESCRIPTION
Various improvements for usability of jshint-mode:
- add a version of flymake-cursor as a convenience, which shows flymake errors in the minibuffer
- also flymake-jshint .js.in files
- flymake would choke on minified lines (emacs hangs on those lines if they have errors). hiding code from the linter error output (but keeping line no and column of errors) fixes that.
- improve server usage string
- log amount of time taken to lint input file
- this pull request includes the dynamic port selection fix (another pull request).
